### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -4,4 +4,8 @@ class DeliveryFee < ActiveHash::Base
     { id: 1, name: '着払い(購入者負担)' },
     { id: 2, name: '送料込み(出品者負担)' }
   ]
+
+  include ActiveHash::Associations
+  has_one :item
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,6 @@ class Item < ApplicationRecord
     validates :delivery_date_id
     validates :genre_id
   end
-  
+
   validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,4 +19,7 @@ class Item < ApplicationRecord
   end
 
   validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
+  
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :delivery_fee
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -143,7 +143,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,28 +123,27 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= '配送料負担' %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,11 +151,10 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,8 +172,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧表示機能の実装。
商品未投稿時→ダミー商品表示の実装。

商品投稿時
https://gyazo.com/2287f6fc40c1849f3cc247098408127d
商品表示
https://gyazo.com/229b2f7f2f5b6d9d9c67e956244e66b2
商品一覧表示(ログアウト状態)
https://gyazo.com/0c30a6fe9ae1dd3a3403eb107db8748e
商品投稿無し
https://gyazo.com/e9914b7accefc50b904f9c0e79fcddac

※商品購入機能実装前のため、sold out表示は未実装です。
# Why
投稿された商品を画面に表示させるため。
未ログインユーザーでも商品一覧が確認できる仕様にするため。
